### PR TITLE
Added support for enter/exit in VBucketAwareMembaseClient

### DIFF
--- a/pymembase/membaseclient.py
+++ b/pymembase/membaseclient.py
@@ -591,6 +591,12 @@ class MemcachedClient(object):
 
 
 class VBucketAwareMembaseClient(object):
+    def __exit__(self, type, value, traceback):
+        self.done()
+
+    def __enter__(self):
+        return self
+
     #poll server every few seconds to see if the vbucket-map
     #has changes
     def __init__(self, url, bucket, password, verbose=False):
@@ -979,7 +985,6 @@ class MemcachedClientHelper(object):
         vBuckets = bucket_info.vbuckets
         for node in bucket_info.nodes:
             if node.ip == ip:
-                print node.memcached
                 client = MemcachedClient(ip, node.memcached)
                 client.vbucket_count = len(vBuckets)
                 client.sasl_auth_plain(bucket_info.name.encode('ascii'),

--- a/pymembase/membaseclient.py
+++ b/pymembase/membaseclient.py
@@ -619,6 +619,7 @@ class VBucketAwareMembaseClient(object):
         self.__init__vbucket_map(self.rest, bucket, -1)
         self.dispatcher = CommandDispatcher(self)
         self.dispatcher_thread = Thread(name="dispatcher-thread", target=self._start_dispatcher)
+        self.dispatcher_thread.daemon = True
         self.dispatcher_thread.start()
         self.vbucket_count = 1024
         self.verbose = verbose


### PR DESCRIPTION
I noticed done() needs to be called or my program wouldn't exit - the dispatcher thread was still running. Rather than need to call it by hand, I added support for 2.5s 'with' statement, so now I can do:

with VBucketAwareMembaseClient(URL, BUCKET, PASSWORD) as c:
   c.get(key)

and not have to worry about calling 'done()'

I also removed the 'print' statement in MemcachedClientHelper
